### PR TITLE
add support for thumbnails, visitors, and fix realtime endpoint

### DIFF
--- a/parsely/models.py
+++ b/parsely/models.py
@@ -8,7 +8,9 @@ class Post():
                  tags=None,
                  hits=None,
                  shares=None,
-                 thumb_urls=None,
+                 thumb_url_medium=None,
+                 image_url=None,
+                 visitors=None,
                  metadata=None):
         self.url = url
         self.title = title
@@ -18,8 +20,10 @@ class Post():
         self.tags = tags
         self.hits = hits
         self.shares = shares
-        self.thumb_urls = thumb_urls
+        self.image_url = image_url
+        self.thumb_url_medium = thumb_url_medium
         self.metadata = metadata
+        self.visitors = visitors
 
     @staticmethod
     def new_from_json_dict(data):
@@ -31,6 +35,9 @@ class Post():
                     tags=data.get('tags', None),
                     hits=data.get('_hits', None),
                     shares=data.get('_shares', None),
+                    visitors=data.get('visitors', None),
+                    thumb_url_medium=data.get('thumb_url_medium', None),
+                    image_url=data.get('image_url', None),
                     metadata=data.get('metadata', None))
 
 

--- a/parsely/parsely.py
+++ b/parsely/parsely.py
@@ -143,7 +143,6 @@ class Parsely(BaseParselyClient):
                                                'pub_date_end': end,
                                                'limit': 10, 'page': 1},
                                               _callback=handler if _callback else None)
-
             return handler(res) if not _callback else None
 
     @valid_kwarg(aspect_map.keys())

--- a/parsely/parsely.py
+++ b/parsely/parsely.py
@@ -152,7 +152,7 @@ class Parsely(BaseParselyClient):
             options['time'] = "%dh" % per.hours if per.hours else "%dm" % per.minutes
 
         handler = self._build_callback(
-            lambda res: [Post.new_from_json_dict(x) for x in res['data']],
+            lambda res: [self.aspect_map[aspect].new_from_json_dict(x) for x in res['data']],
             _callback)
         res = self.conn._request_endpoint('/realtime/%s' % aspect, options,
                                           _callback=handler if _callback else None)


### PR DESCRIPTION
This PR fixes a couple of things I encountered while I was using it to build slackbot:

1) the Post model had a self.thumb_urls that was never populated and no field for visitors. I added support for thumb_url_medium, image_url, and visitors so those can be accessed once populated from the API.

2) /realtime endpoint always called Post.new_from_json_dict, which would break it when asking for realtime data for other metas. Fixed so that it properly calls new_from_json_dict for the correct aspect when making a realtime query